### PR TITLE
decorators.py: Improve yield_once speed

### DIFF
--- a/coala_decorators/decorators.py
+++ b/coala_decorators/decorators.py
@@ -4,7 +4,8 @@ from functools import total_ordering
 
 def yield_once(iterator):
     """
-    Decorator to make an iterator yield each result only once.
+    Decorator to make an iterator returned by a method yield each result only
+    once.
 
     >>> @yield_once
     ... def generate_list(foo):
@@ -12,8 +13,9 @@ def yield_once(iterator):
     >>> list(generate_list([1, 2, 1]))
     [1, 2]
 
-    :param iterator: Any iterator
-    :return:         An iterator that yields every result only once at most.
+    :param iterator: Any method that returns an iterator
+    :return:         An method returning an iterator
+                     that yields every result only once at most.
     """
     def yield_once_generator(*args, **kwargs):
         yielded = []

--- a/coala_decorators/decorators.py
+++ b/coala_decorators/decorators.py
@@ -1,5 +1,5 @@
 import inspect
-from functools import total_ordering
+from functools import total_ordering, wraps
 
 
 def yield_once(iterator):
@@ -17,6 +17,7 @@ def yield_once(iterator):
     :return:         An method returning an iterator
                      that yields every result only once at most.
     """
+    @wraps(iterator)
     def yield_once_generator(*args, **kwargs):
         yielded = set()
         for item in iterator(*args, **kwargs):

--- a/coala_decorators/decorators.py
+++ b/coala_decorators/decorators.py
@@ -18,12 +18,12 @@ def yield_once(iterator):
                      that yields every result only once at most.
     """
     def yield_once_generator(*args, **kwargs):
-        yielded = []
+        yielded = set()
         for item in iterator(*args, **kwargs):
             if item in yielded:
                 pass
             else:
-                yielded.append(item)
+                yielded.add(item)
                 yield item
 
     return yield_once_generator

--- a/coala_decorators/decorators.py
+++ b/coala_decorators/decorators.py
@@ -6,6 +6,12 @@ def yield_once(iterator):
     """
     Decorator to make an iterator yield each result only once.
 
+    >>> @yield_once
+    ... def generate_list(foo):
+    ...     return foo
+    >>> list(generate_list([1, 2, 1]))
+    [1, 2]
+
     :param iterator: Any iterator
     :return:         An iterator that yields every result only once at most.
     """

--- a/coala_decorators/decorators.py
+++ b/coala_decorators/decorators.py
@@ -20,9 +20,7 @@ def yield_once(iterator):
     def yield_once_generator(*args, **kwargs):
         yielded = set()
         for item in iterator(*args, **kwargs):
-            if item in yielded:
-                pass
-            else:
+            if item not in yielded:
                 yielded.add(item)
                 yield item
 


### PR DESCRIPTION
Changes:
- yield_once uses a set instead of a list to lookup already seen items
- change the docstring to clarify that it does not wrap iterators but methods that return iterators
- a doctest verifies that it works.

In order to run the doctests, type

```
python -m doctest coala_decorators/decorators.py
```

I wasn't sure whether there is a CI unit test suite yet, so I just created a simple doctest. This might be related to issue #9. Please let me know if anything can be improved.
